### PR TITLE
feat: catch failures + support laravel 6 + improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+testing

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         }
     ],
     "require": {
+        "php": ">=7.2",
         "laravel/framework": "^5.8 || ^6.0",
         "nunomaduro/laravel-console-task": "^1.2",
         "sixlive/dotenv-editor": "^1.2"
@@ -21,7 +22,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "harmonic\\LaravelPreset\\PresetServiceProvider"
+                "harmonic\\LaravelPreset\\LaravelPresetServiceProvider"
             ]
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "laravel/framework": "^5.8",
+        "laravel/framework": "^5.8 || ^6.0",
         "nunomaduro/laravel-console-task": "^1.2",
         "sixlive/dotenv-editor": "^1.2"
     },

--- a/src/LaravelPresetServiceProvider.php
+++ b/src/LaravelPresetServiceProvider.php
@@ -5,7 +5,7 @@ namespace harmonic\LaravelPreset;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\Console\PresetCommand;
 
-class PresetServiceProvider extends ServiceProvider {
+class LaravelPresetServiceProvider extends ServiceProvider {
     public function boot() {
         PresetCommand::macro('harmonic', function ($command) {
             // Do the preset work

--- a/src/Preset.php
+++ b/src/Preset.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Console\Presets\Preset as BasePreset;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use sixlive\DotenvEditor\DotenvEditor;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
 class Preset extends BasePreset
@@ -156,7 +157,11 @@ class Preset extends BasePreset
                 copy(__DIR__ . '/stubs/.eslintrc.js', base_path('.eslintrc.js'));
             });
             $this->command->task('Setup tailwindcss', function () {
-                $this->runCommand('yarn tailwind init');
+                try {
+                    $this->runCommand('yarn tailwind init');
+                } catch (ProcessFailedException $e) {
+                    // Tailwind already setup by the theme
+                }
             });
             $this->command->task('Run node dev build with Yarn', function () {
                 $this->runCommand('yarn dev');

--- a/src/Preset.php
+++ b/src/Preset.php
@@ -18,7 +18,7 @@ class Preset extends BasePreset {
         ],
         'silber/bouncer' => [
             'repo' => 'https://github.com/JosephSilber/bouncer',
-            'version' => 'v1.0.0-rc.5',
+            'version' => 'v1.0.0-rc.6',
         ],
         'harmonic/laravel-envcoder' => [
             'repo' => 'https://github.com/Harmonic/laravel-envcoder',
@@ -88,7 +88,7 @@ class Preset extends BasePreset {
             ];
             $this->packages['harmonic/inertia-table'] = [
                 'repo' => 'https://github.com/harmonic/inertia-table',
-                'version' => '^1.0.0'
+                'version' => '^1.1.0'
             ];
             $this->options['packages'][] = 'inertiajs/inertia-laravel';
             $this->options['packages'][] = 'harmonic/inertia-table';

--- a/src/Preset.php
+++ b/src/Preset.php
@@ -2,16 +2,22 @@
 
 namespace harmonic\LaravelPreset;
 
-use sixlive\DotenvEditor\DotenvEditor;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Arr;
-use Illuminate\Foundation\Console\Presets\Preset as BasePreset;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Console\PresetCommand;
+use Illuminate\Foundation\Console\Presets\Preset as BasePreset;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use sixlive\DotenvEditor\DotenvEditor;
+use Symfony\Component\Process\Process;
 
-class Preset extends BasePreset {
+class Preset extends BasePreset
+{
+    /** @var PresetCommand */
     protected $command;
+
     protected $options = [];
     protected static $installTheme = false;
+
     protected $packages = [
         'bensampo/laravel-enum' => [
             'repo' => 'https://github.com/BenSampo/laravel-enum',
@@ -33,41 +39,49 @@ class Preset extends BasePreset {
             'dev' => true,
         ],
         'Jorijn/laravel-security-checker' => [
-            'repo' => 'https://github.com/Jorijn/laravel-security-checker'
+            'repo' => 'https://github.com/Jorijn/laravel-security-checker',
         ],
     ];
+
     protected $themePackages = [
         'tightenco/ziggy' => [
             'repo' => 'https://github.com/tightenco/ziggy',
         ],
         'reinink/remember-query-strings' => [
             'repo' => 'https://github.com/reinink/remember-query-strings',
-        ]
+        ],
     ];
+
     protected static $jsInclude = [
         '@babel/plugin-syntax-dynamic-import' => '^7.2.0',
         'browser-sync' => '^2.26.5',
         'browser-sync-webpack-plugin' => '2.0.1',
     ];
+
     protected static $jsExclude = [];
 
-    public function __construct($command) {
+    public function __construct($command)
+    {
         $this->command = $command;
     }
 
-    public static function install($command) {
+    public static function install($command): void
+    {
         (new static($command))->run();
     }
 
-    public function run() {
+
+    public function run(): void
+    {
         $this->command->info('=================');
         $this->command->info(' Harmonic Preset');
         $this->command->info('=================');
         $this->command->info('Before you run the preset please confirm you have:');
         $this->command->info('✔️  Set up and configured your database and URL in .env');
-        $this->command->info('✔️  Run the intial Laravel migrations with php artisan migrate');
+        $this->command->info('✔️  Run the initial Laravel migrations with php artisan migrate');
         $this->command->info('✔️  Have yarn installed globally');
         $continue = $this->command->confirm("Yes, I've done all this, lets get creating!", true);
+
         if (!$continue) {
             return;
         }
@@ -84,14 +98,15 @@ class Preset extends BasePreset {
         if ($this->options['install_inertia']) {
             $this->packages['inertiajs/inertia-laravel'] = [
                 'repo' => 'https://github.com/inertiajs/inertia-laravel',
-                'version' => '^0.1.0'
+                'version' => '^0.2.0',
             ];
             $this->packages['harmonic/inertia-table'] = [
                 'repo' => 'https://github.com/harmonic/inertia-table',
-                'version' => '^1.1.0'
+                'version' => '^1.0.7',
             ];
             $this->options['packages'][] = 'inertiajs/inertia-laravel';
             $this->options['packages'][] = 'harmonic/inertia-table';
+
             self::$jsInclude = array_merge(self::$jsInclude, [
                 '@inertiajs/inertia' => '^0.1.0',
                 '@inertiajs/inertia-vue' => '^0.1.0',
@@ -118,7 +133,7 @@ class Preset extends BasePreset {
                 'laravel-mix-purgecss' => '^4.1.0',
                 'postcss-import' => '^12.0.1',
                 'postcss-nesting' => '^7.0.0',
-                'tailwindcss' => '>=1.0.0'
+                'tailwindcss' => '>=1.0.0',
             ]);
 
             self::$jsExclude = array_merge(self::$jsExclude, [
@@ -126,10 +141,10 @@ class Preset extends BasePreset {
                 'bootstrap-sass',
                 'jquery',
                 'sass',
-                'sass-loader'
+                'sass-loader',
             ]);
 
-            $this->command->task('Install Tailwindcss', function () {
+            $this->command->task('Install tailwindcss', function () {
                 static::ensureComponentDirectoryExists();
                 static::updatePackages();
                 $this->tailwindTemplate();
@@ -140,7 +155,7 @@ class Preset extends BasePreset {
                 $this->runCommand('yarn add -D eslint eslint-plugin-vue');
                 copy(__DIR__ . '/stubs/.eslintrc.js', base_path('.eslintrc.js'));
             });
-            $this->command->task('Setup Tailwindcss', function () {
+            $this->command->task('Setup tailwindcss', function () {
                 $this->runCommand('yarn tailwind init');
             });
             $this->command->task('Run node dev build with Yarn', function () {
@@ -179,7 +194,8 @@ class Preset extends BasePreset {
         $this->outputSuccessMessage();
     }
 
-    private function tailwindTemplate() {
+    private function tailwindTemplate(): void
+    {
         tap(new Filesystem, function ($files) {
             $files->deleteDirectory(resource_path('sass'));
             $files->delete(public_path('css/app.css'));
@@ -199,11 +215,13 @@ class Preset extends BasePreset {
         }
     }
 
-    protected static function updatePackageArray(array $packages) {
+    protected static function updatePackageArray(array $packages): array
+    {
         return array_merge(static::$jsInclude, Arr::except($packages, static::$jsExclude));
     }
 
-    private function gatherOptions() {
+    private function gatherOptions(): array
+    {
         $options = [
             'cypress' => $this->command->confirm('Install cypress for front end testing?', true),
             'theme' => $this->command->confirm('Install harmonic theme?', true),
@@ -219,7 +237,8 @@ class Preset extends BasePreset {
         return $options;
     }
 
-    private function promptForPackagesToInstall() {
+    private function promptForPackagesToInstall(): array
+    {
         $possiblePackages = $this->packages();
         $choices = $this->command->choice(
             'Which optional packages should be installed? (e.x. 1,2)',
@@ -228,37 +247,42 @@ class Preset extends BasePreset {
             null,
             true
         );
-        if (in_array('all', $choices)) {
+        if (in_array('all', $choices, true)) {
             return $possiblePackages;
         }
-        if (in_array('none', $choices)) {
+        if (in_array('none', $choices, true)) {
             return [];
         }
+
         return $choices;
     }
 
-    private function updateComposerPackages() {
+    private function updateComposerPackages(): void
+    {
         $this->runCommand(sprintf(
             'composer require %s',
             $this->resolveForComposer($this->options['packages'])
         ));
     }
 
-    private function packages() {
+    private function packages(): array
+    {
         return Collection::make($this->packages)
             ->where('dev', false)
             ->keys()
             ->toArray();
     }
 
-    private function devPackages() {
+    private function devPackages(): array
+    {
         return Collection::make($this->packages)
             ->where('dev', true)
             ->keys()
             ->toArray();
     }
 
-    private function resolveForComposer($packages) {
+    private function resolveForComposer($packages): string
+    {
         return Collection::make($packages)
             ->transform(function ($package) {
                 return isset($this->packages[$package]['version'])
@@ -268,14 +292,16 @@ class Preset extends BasePreset {
             ->implode(' ');
     }
 
-    private function updateComposerDevPackages() {
+    private function updateComposerDevPackages(): void
+    {
         $this->runCommand(sprintf(
             'composer require --dev %s',
             $this->resolveForComposer($this->devPackages())
         ));
     }
 
-    private function installTheme() {
+    private function installTheme(): void
+    {
         $this->options['install_tailwind'] = true;
         $this->options['install_inertia'] = true;
 
@@ -315,11 +341,10 @@ class Preset extends BasePreset {
             $files->copyDirectory(__DIR__ . '/stubs/theme/Auth', app_path('Http/Controllers/Auth'));
             $files->copyDirectory(__DIR__ . '/stubs/theme/Traits', app_path('Traits'));
         });
-
-        return true;
     }
 
-    private function updateEnvFile() {
+    private function updateEnvFile(): void
+    {
         tap(new DotenvEditor, function ($editor) {
             $editor->load(base_path('.env'));
             $editor->set('LCS_MAIL_TO', 'email@toreceiveupdates.com');
@@ -332,27 +357,32 @@ class Preset extends BasePreset {
         });
     }
 
-    private function updateGitignore() {
+    private function updateGitignore(): void
+    {
         copy(__DIR__ . '/stubs/gitignore-stub', base_path('.gitignore'));
         copy(__DIR__ . '/stubs/disable.xdebug.ini', base_path('disable.xdebug.ini'));
         copy(__DIR__ . '/stubs/run-tests.sh', base_path('run-tests.sh'));
         chmod(base_path('run-tests.sh'), 0755);
     }
 
-    private function runCommand($command) {
-        return exec(sprintf('%s 2>&1', $command));
+    private function runCommand($command): void
+    {
+        $process = Process::fromShellCommandline(sprintf('%s 2>&1', $command));
+        $process->mustRun(); // Throws exception on failure
     }
 
-    private function getInstalledPackages() {
+    private function getInstalledPackages(): array
+    {
         return Collection::make($this->packages)
             ->filter(function ($data, $package) {
-                return in_array($package, $this->options['packages'])
+                return in_array($package, $this->options['packages'], true)
                     || ($data['dev'] ?? false);
             })
             ->toArray();
     }
 
-    private function outputSuccessMessage() {
+    private function outputSuccessMessage(): void
+    {
         $this->command->line('');
         $this->command->info('🎉  Preset installation complete. The packages that were installed may require additional installation steps.');
         $this->command->line('');

--- a/src/Preset.php
+++ b/src/Preset.php
@@ -160,7 +160,7 @@ class Preset extends BasePreset
                 try {
                     $this->runCommand('yarn tailwind init');
                 } catch (ProcessFailedException $e) {
-                    // Tailwind already setup by the theme
+                    $this->command->info('Tailwind already configured, skipping');
                 }
             });
             $this->command->task('Run node dev build with Yarn', function () {

--- a/test.php
+++ b/test.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Script to setup a fresh laravel install for testing out the preset
+ */
+
+
+use Symfony\Component\Process\Process;
+
+require_once 'vendor/autoload.php';
+
+function run(string $command)
+{
+    echo 'COMMAND > ' . $command . "\n";
+    $process = Process::fromShellCommandline($command);
+    $process->run(function ($type, $buffer) {
+        if (Process::ERR === $type) {
+            echo 'ERR > ' . $buffer;
+        } else {
+            echo 'OUT > ' . $buffer;
+        }
+    });
+}
+
+$pathToInstall = '/tmp/testing-preset';
+
+run("rm -rf $pathToInstall");
+run('cd /tmp && composer create-project --prefer-dist laravel/laravel testing-preset');
+
+$composerJson = json_decode(file_get_contents($pathToInstall . '/composer.json'), true);
+echo json_last_error_msg();
+$composerJson['repositories'][] = ['type' => 'path', 'url' => __DIR__];
+$composerJson['require']['harmonic/laravel-preset'] = '*';
+
+file_put_contents($pathToInstall . '/composer.json', json_encode($composerJson, JSON_PRETTY_PRINT));
+
+run("cd $pathToInstall && composer update");
+


### PR DESCRIPTION
Replaces my previous PR, #2 

Note: This needs https://github.com/Harmonic/inertia-table/pull/17 to be merged first

I've made a bunch of changes, namely: 

- Added a quick script to spin up a new install for testing
- Switched execution of commands to `Symfony\Process` package, meaning that exceptions will be thrown on failure, so the errors are helpful (see screenshot)
- Fixed incorrectly named service provider
- Support laravel 6
- Fix formatting/typos + type hints

Closes #4
Closes #1